### PR TITLE
Use XDG location for pylint cache

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -93,10 +93,12 @@ localized using the following rules:
 
 * value of the PYLINTHOME environment variable if set
 
-* ".pylint.d" subdirectory of the user's home directory if it is found
-	(not always findable on Windows platforms)
+* ``$XDG_CACHE_HOME/pylint`` if ``XDG_CACHE_HOME`` is defined,
+  otherwise ``$HOME/.cache/pylint`` if the home directory is
+  available
 
-* ".pylint.d" directory in the current directory
+* ``.pylint.d`` directory in the current directory if the home
+  directory cannot be determined
 
 3.3 How do I find the option name (for pylintrc) corresponding to a specific command line option?
 --------------------------------------------------------------------------------------------------------

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -60,10 +60,14 @@ if "PYLINTHOME" in os.environ:
     PYLINT_HOME = os.environ["PYLINTHOME"]
     if USER_HOME == "~":
         USER_HOME = os.path.dirname(PYLINT_HOME)
-elif USER_HOME == "~":
-    PYLINT_HOME = ".pylint.d"
 else:
-    PYLINT_HOME = os.path.join(USER_HOME, ".pylint.d")
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        PYLINT_HOME = os.path.join(xdg_cache_home, "pylint")
+    elif USER_HOME == "~":
+        PYLINT_HOME = ".pylint.d"
+    else:
+        PYLINT_HOME = os.path.join(USER_HOME, ".cache", "pylint")
 
 
 def _get_pdata_path(base_name, recurs):

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -628,10 +628,14 @@ def pop_pylintrc():
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_pylint_home():
     uhome = os.path.expanduser("~")
-    if uhome == "~":
+    if "XDG_CACHE_HOME" in os.environ:
+        cache_home = os.environ["XDG_CACHE_HOME"]
+    else:
+        cache_home = os.path.join(uhome, ".cache")
+    if uhome == "~" and "XDG_CACHE_HOME" not in os.environ:
         expected = ".pylint.d"
     else:
-        expected = os.path.join(uhome, ".pylint.d")
+        expected = os.path.join(cache_home, "pylint")
     assert config.PYLINT_HOME == expected
 
     try:


### PR DESCRIPTION
## Summary
- store pylint cache under `$XDG_CACHE_HOME` if available
- document the new location for persistent data
- update tests for `PYLINT_HOME`

## Testing
- `pytest tests/lint/unittest_lint.py::test_pylint_home -q`

------
https://chatgpt.com/codex/tasks/task_e_68516ace8d40832a90c29228e2227e83